### PR TITLE
fix broken hyperlink

### DIFF
--- a/content/en/blog/the-akashian-challenge-phase-1-cygni-release-announcement/index.md
+++ b/content/en/blog/the-akashian-challenge-phase-1-cygni-release-announcement/index.md
@@ -38,10 +38,9 @@ Connect with us on [our Telegram](https://t.me/AkashNW), or [our Riot dev chat](
   
 **Go forth Akashians!**
 
-[**Get Started Now**  
-](https://docs.akash.network/akashian/centauri-2)[**Learn More**  
-  
-](https://akash.network/challenge/)
+[**Get Started Now**](https://docs.akash.network/akashian/centauri-2)
+
+[**Learn More**](https://akash.network/challenge/)
 
 ### **Cygni Release**  
 **\_\_\_\_\_**


### PR DESCRIPTION
Signed-off-by: figurestudios <64747030+figurestudios@users.noreply.github.com>

## Summary

Fix broken hyperlink, see how it looks on the [current page](https://akash.network/blog/the-akashian-challenge-phase-1-cygni-release-announcement/):

![image](https://user-images.githubusercontent.com/64747030/212176770-0df5094e-3223-4488-81c7-8cc9f05ed2ea.png)

No content is changed.

## Checks

I have not run `npm run test`, assuming this is automated via GitHub Actions. I have only changed a few characters in an index.md file 😆 